### PR TITLE
Enable ros1_bridge to bridge services that contain array field(s) in their definition

### DIFF
--- a/ros1_bridge/__init__.py
+++ b/ros1_bridge/__init__.py
@@ -610,7 +610,7 @@ def determine_common_services(
                 if ros1_type != ros2_type or ros1_name != ros2_name:
                     # if the message types have a custom mapping their names
                     # might not be equal, therefore check the message pairs
-                    if (ros1_type, ros2_type) not in message_string_pairs:
+                    if (ros1_type.rstrip("[]"), ros2_type.rstrip("[]")) not in message_string_pairs:
                         match = False
                         break
                 output[direction].append({


### PR DESCRIPTION
This PR enables the ros1_bridge to bridge services between ROS1/ROS2 that contain an array field in the service definition's request and/or response. It is carried-over from [this commit](https://github.com/ros2/ros1_bridge/pull/347/commits/d9352dabb5f72cd8ea805656d6b17a846567a9d5) to [this PR](https://github.com/ros2/ros1_bridge/pull/347) on the official ros1_bridge repository.

This was tested locally using the /guidance/get_available_routes service (which contains an array field in the response) between ROS1 and ROS2.

Link to related github issue: [Issue #1797](https://github.com/usdot-fhwa-stol/carma-platform/issues/1797)